### PR TITLE
test: add weak crypto usage for CodeQL demo

### DIFF
--- a/src/main/java/org/apache/commons/lang3/VulnerableExample.java
+++ b/src/main/java/org/apache/commons/lang3/VulnerableExample.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.lang3;
+
+import java.security.MessageDigest;
+
+public class VulnerableExample {
+    // still here to keep your coverage test
+    private static final String PASSWORD = "admin123";
+
+    public String getPasswordForTestCoverageOnly() {
+        return PASSWORD;
+    }
+
+    // Weak cryptographic algorithm (CodeQL will flag)
+    public byte[] weakHash(byte[] data) throws Exception {
+        MessageDigest md = MessageDigest.getInstance("MD5"); // flagged
+        return md.digest(data);
+    }
+}
+
+

--- a/src/test/java/org/apache/commons/lang3/VulnerableExampleTest.java
+++ b/src/test/java/org/apache/commons/lang3/VulnerableExampleTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.lang3;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class VulnerableExampleTest {
+    @Test
+    void coversClass() throws Exception {
+        VulnerableExample v = new VulnerableExample();
+        assertEquals("admin123", v.getPasswordForTestCoverageOnly());
+        v.weakHash("abc".getBytes());
+    }
+}
+


### PR DESCRIPTION
**Purpose:**
Introduce a deliberately vulnerable code snippet to trigger a CodeQL security alert during scanning.

**Details:**

- Added a new Java class VulnerableExample containing weak cryptographic logic.

- Created a corresponding unit test VulnerableExampleTest to ensure the file is included in build and test coverage.

**Expected Outcome:**

- CodeQL workflow should run successfully.

- A new Code scanning alert should appear for the weak cryptography usage.

**Note:**
This change is solely for testing the CodeQL analysis workflow and validating detection of known security issues.