### PR TITLE
Add custom CodeQL query to detect MD5 usage

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -66,7 +66,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          queries: security-and-quality
+          queries: security-and-quality,./codeql-custom-queries/java
 
       # Try the automatic build first
       - name: Autobuild

--- a/codeql-custom-queries/java/codeql-pack.yml
+++ b/codeql-custom-queries/java/codeql-pack.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####This file tells GitHub that this folder contains a CodeQL query pack.
+name: my-org/custom-queries-java
+version: 0.0.1
+libraryPathDependencies: codeql/java-all
+extractor: java

--- a/codeql-custom-queries/java/custom-md5.ql
+++ b/codeql-custom-queries/java/custom-md5.ql
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ import java
+import semmle.code.java.security.MessageDigest
+
+from MessageDigestCall md
+where md.getAlgorithm().toLowerCase() = "md5"
+select md, "Avoid using MD5. Use SHA-256 or better."


### PR DESCRIPTION
This PR introduces a custom CodeQL query to detect usage of the MD5 hashing algorithm in Java code.
MD5 is considered cryptographically weak and unsuitable for security-sensitive purposes.
The query scans the codebase for calls to MessageDigest.getInstance("MD5") and flags them for review,
helping maintainers identify and replace insecure hash functions with stronger alternatives (e.g., SHA-256).

Changes include:

Added md5-usage.ql under codeql-custom-queries/java/.

Updated codeql-pack.yml to include the new query pack.

Updated CodeQL workflow to run custom queries alongside the default security-and-quality queries.